### PR TITLE
chore: camelcase naming

### DIFF
--- a/pages/wbips/WBIP006.md
+++ b/pages/wbips/WBIP006.md
@@ -26,14 +26,14 @@ Returns: {
 ## Examples
 
 ```js
-window.webbtc.request("signPSBT", {
+window.webbtc.request("signPsbt", {
   psbt: "dcb512383d92f70c5a0014db9f936fe9…8e89bf02b618df3aa4545e4c647ce3a1",
   signInputs: [0, 1],
 });
 ```
 
 ```js
-window.webbtc.request("signPSBT", {
+window.webbtc.request("signPsbt", {
   psbt: "dcb512383d92f70c5a0014db9f936fe9…8e89bf02b618df3aa4545e4c647ce3a1",
   signInputs: {
     "1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu": [0],


### PR DESCRIPTION
Considers acronyms words in camelcase, so to avoid confusing markups when multiple acronyms are merged e.g. `signPSBTAnotherWord` -> Brain reads _PSBTA nother_